### PR TITLE
0.3.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ let vitalik = "vitalik.eth"
 let vitalikURL = try await enskit.resolve(name: vitalik)
 ```
 
-Get domain avatar URL:
+Get domain avatar as `Data`:
 
 ```swift
 // in async function
@@ -37,6 +37,15 @@ let vitalik = "vitalik.eth"
 let vitalikAvatar = try await enskit.avatar(name: vitalik)
 ```
 
+Get domain avatar URL:
+```swift
+// in async function
+let vitalik = "vitalik.eth"
+if let avatar = try await enskit.getAvatar(name: vitalik) {
+    let url = try await enskit.getAvatarImageURL(avatar: avatar)
+}
+```
+
 ## License
 
-MIT (See [LICENSE](/LICENSE))
+[MIT](/LICENSE)

--- a/Sources/ENSKit/Utility/String+Extension.swift
+++ b/Sources/ENSKit/Utility/String+Extension.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import CryptoSwift
+import UInt256
 
 public extension String {
     @inlinable
@@ -23,5 +24,40 @@ public extension String {
     @inlinable
     func encodeBase64() -> String {
         return self.data(using: .utf8)!.base64EncodedString()
+    }
+}
+
+extension String {
+    func isHTTPSURL() -> Bool {
+        return self.range(of: "https://", options: [.caseInsensitive, .anchored]) != nil
+    }
+
+    func isIPFSURL() -> Bool {
+        return self.range(of: "ip[fn]s://", options: [.caseInsensitive, .anchored, .regularExpression]) != nil
+    }
+
+    func isDataURL() -> Bool {
+        return self.range(of: "data:", options: [.caseInsensitive, .anchored]) != nil
+    }
+
+    func matchERCTokens() -> (String, Address, UInt256)? {
+        // ERC721 naming convention: [CAIP-22](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-22.md)
+        // ERC1155 naming convention: [CAIP-29](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-29.md)
+
+        let tokensMatcher = try! NSRegularExpression(pattern: #"^eip155:[0-9]+/(erc[0-9]+):(0x[0-9a-f]{40})/([0-9]+)$"#, options: [.caseInsensitive])
+        let range = NSRange(self.startIndex..<self.endIndex, in: self)
+        guard let match = tokensMatcher.firstMatch(in: self, range: range), match.numberOfRanges == 4 else {
+            return nil
+        }
+
+        let tokenTypeRange = Range(match.range(at: 1), in: self)!
+        let tokenAddressRange = Range(match.range(at: 2), in: self)!
+        let tokenIdRange = Range(match.range(at: 3), in: self)!
+
+        let tokenType = String(self[tokenTypeRange]).lowercased()
+        let tokenAddress = try! Address(String(self[tokenAddressRange]))
+        let tokenId = UInt256(self[tokenIdRange])!
+
+        return (tokenType, tokenAddress, tokenId)
     }
 }

--- a/Tests/ENSKitTests/ENSKitTests.swift
+++ b/Tests/ENSKitTests/ENSKitTests.swift
@@ -11,9 +11,13 @@ import XCTest
 final class ENSKitTests: XCTestCase {
     let main = ENSKit()
 
-    func testAvatar() async throws {
-        let avatar = try await main.avatar(name: "vitalik.eth")
-        XCTAssertEqual(avatar, URL(string: "ipfs://ipfs/QmSP4nq9fnN9dAiCj42ug9Wa79rqmQerZXZch82VqpiH7U/image.gif")!)
+    func testAvatarURL() async throws {
+        if let avatar = try await main.getAvatar(name: "vitalik.eth") {
+            let avatarURL = try await main.getAvatarImageURL(avatar: avatar)
+            XCTAssertEqual(avatarURL, URL(string: "ipfs://ipfs/QmSP4nq9fnN9dAiCj42ug9Wa79rqmQerZXZch82VqpiH7U/image.gif")!)
+        } else {
+            XCTFail()
+        }
     }
 
     func testResolveIPFS() async throws {


### PR DESCRIPTION
- `avatar()` now returns `Data` instead of a URL.
  - It's quite difficult for application to handle an avatar stored as an IPFS link. As we already have a way to retrieve content from IPFS gateway, it's better to just use it. If the application is capable of providing an IPFS client implementation, it will be used here.
- Handle `data:` URI (supported by [ENS avatar spec](https://docs.ens.domains/ens-improvement-proposals/ensip-12-avatar-text-records)) in avatar records correctly.
  - `URLRequest` can resolve `data:` URI just fine.